### PR TITLE
Change user agent from code.json request

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function main(addresses) {
         rejectUnauthorized: false,
         headers: {
           'Accept': 'application/json',
-          'User-Agent': 'Code-Gov'
+          'User-Agent': 'code.gov'
         }
       }
       return getCodeJson(requestOptions)


### PR DESCRIPTION
# Why

Some requests are returning a timeout when requesting the code.json from agencies. It has to do with how we report our user-agent during the request. Changing it to a value that the agency servers will accept helps us keep request errors.

# What Changed

- Changing the user-agent will help us have more reliable code.json requests. - fd4a40d