### PR TITLE
Transportation treasury changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,8 +58,8 @@ typings/
 .env
 
 .vscode
-releases-*.json
-releasesIndex-*.json
+releases*.json
+processed_agency_repo_count*.json
 *.zip
 .DS_Store
 

--- a/libs/utils.js
+++ b/libs/utils.js
@@ -144,7 +144,9 @@ function mergeJson(mergeTo, mergeFrom) {
   const keys = Object.keys(mergeFrom)
 
   keys.forEach((key) => {
-    mergeTo[key] = mergeFrom[key]
+    if(!mergeTo.hasOwnProperty(key)) {
+      mergeTo[key] = mergeFrom[key]
+    }
   })
 
   return mergeTo


### PR DESCRIPTION
# Why

There were inconsistencies in how we would consume and display the code.json data from the DOT and Treasury.

# What changed

Add report file and change user-agent - d5f54c4
- Added processed_agency_repo_cound.json report creation. Show the amount of repos processed per agency.
- Changed user-agent to code.gov to avoid request timeout.

Fixed merge bug. - 4d8d2a3
- Merge would overwrite existing data. Added verification to avoid this.

Add created data files to ignore. - e3b7118