### PR TITLE
DOJ URL requires www to avoid http 301 direct

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,7 +173,7 @@ main([
   'https://www.defense.gov/code.json',
   'https://energy.gov/code.json',
   'https://data.doi.gov/code.json',
-  'https://justice.gov/code.json',
+  'https://www.justice.gov/code.json',
   'https://www.dol.gov/code.json',
   'http://state.gov/code.json',
   'https://www.transportation.gov/code.json',


### PR DESCRIPTION
Solves the timeout issue on harvester execution