### PR TITLE
Fix schema properties

### DIFF
--- a/schemas/code_2_0_0.json
+++ b/schemas/code_2_0_0.json
@@ -250,17 +250,14 @@
               "properties": {
                 "created": {
                   "type": "string",
-                  "format": "date",
                   "description": "The date the release was created, in YYYY-MM-DD or ISO 8601 format."
                 },
                 "lastModified": {
                   "type": "string",
-                  "format": "date",
                   "description": "The date the release was modified, in YYYY-MM-DD or ISO 8601 format."
                 },
                 "metadataLastUpdated": {
                   "type": "string",
-                  "format": "date",
                   "description": "The date the metadata of the release was last updated, in YYYY-MM-DD or ISO 8601 format."
                 }
               },

--- a/schemas/code_2_0_0.json
+++ b/schemas/code_2_0_0.json
@@ -198,8 +198,11 @@
                   "URL": {
                     "type": "string",
                     "description": "The URL where the code repository, project, library or release can be found."
+                  },
+                  "isGovernmentRepo": {
+                    "type": "boolean",
+                    "description": "True or False field indicating if the project is a government repository"
                   }
-                  
                 },
                 "additionalProperties": false
               }


### PR DESCRIPTION
# Why

Schema wasn't following the documentation 100%.

# What changed

-Added property to relatedCode - 24fbe1e
  - Added isGovernmentRepo to the relatedCode object.
- Removed the format from the date object. - 57d82da
  - Our schema updater is setting the date fields as empty strings. This will make the validations fail. We will remove the format until we find a better way to work with this.