### PR TITLE
Fix reporting bugs

### DIFF
--- a/data/agencyMetadata.json
+++ b/data/agencyMetadata.json
@@ -5,7 +5,7 @@
       "website": "https://usda.gov/",
       "codeUrl": "https://www.usda.gov/code.json",
       "requirements": {
-        "agencyWidePolicy": 0.5,
+        "agencyWidePolicy": 0.75,
         "openSourceRequirement": 0,
         "inventoryRequirement": 0,
         "schemaFormat": 0.5,
@@ -19,7 +19,7 @@
       "website": "https://www.commerce.gov/",
       "codeUrl": "https://www.commerce.gov/code.json",
       "requirements": {
-        "agencyWidePolicy": 0.5,
+        "agencyWidePolicy": 0.75,
         "openSourceRequirement": 0,
         "inventoryRequirement": 0,
         "schemaFormat": 0.5,
@@ -61,9 +61,9 @@
       "website": "https://energy.gov/",
       "codeUrl": "https://www.energy.gov/code.json",
       "requirements": {
-        "agencyWidePolicy": 0,
-        "openSourceRequirement": 0,
-        "inventoryRequirement": 0,
+        "agencyWidePolicy": 0.75,
+        "openSourceRequirement": 1,
+        "inventoryRequirement": 1,
         "schemaFormat": 0.5,
         "overallCompliance": 0
       }
@@ -89,9 +89,9 @@
       "website": "https://www.hud.gov/",
       "codeUrl": "https://www.hud.gov/code.json",
       "requirements": {
-        "agencyWidePolicy": 0.5,
+        "agencyWidePolicy": 0.75,
         "openSourceRequirement": 0,
-        "inventoryRequirement": 0,
+        "inventoryRequirement": 1,
         "schemaFormat": 0.5,
         "overallCompliance": 0
       }
@@ -103,7 +103,7 @@
       "website": "https://www.dhs.gov",
       "codeUrl": "https://www.dhs.gov/code.json",
       "requirements": {
-        "agencyWidePolicy": 0,
+        "agencyWidePolicy": 1,
         "openSourceRequirement": 0,
         "inventoryRequirement": 0,
         "schemaFormat": 0.5,
@@ -131,7 +131,7 @@
       "website": "https://justice.gov",
       "codeUrl": "https://www.justice.gov/code.json",
       "requirements": {
-        "agencyWidePolicy": 0.5,
+        "agencyWidePolicy": 0.75,
         "openSourceRequirement": 0,
         "inventoryRequirement": 0,
         "schemaFormat": 0.5,
@@ -186,7 +186,7 @@
       "website": "https://www.treasury.gov/",
       "codeUrl": "https://www.treasury.gov/code.json",
       "requirements": {
-        "agencyWidePolicy": 0.5,
+        "agencyWidePolicy": 0.75,
         "openSourceRequirement": 0,
         "inventoryRequirement": 0,
         "schemaFormat": 0.5,
@@ -212,7 +212,7 @@
       "website": "https://epa.gov/",
       "codeUrl": "https://www.epa.gov/code.json",
       "requirements": {
-        "agencyWidePolicy": 0.5,
+        "agencyWidePolicy": 0,
         "openSourceRequirement": 0.5,
         "inventoryRequirement": 0,
         "schemaFormat": 0.5,
@@ -240,7 +240,7 @@
       "requirements": {
         "agencyWidePolicy": 1,
         "openSourceRequirement": 0,
-        "inventoryRequirement": 0.5,
+        "inventoryRequirement": 0,
         "schemaFormat": 0.5,
         "overallCompliance": 0
       }
@@ -278,9 +278,9 @@
       "website": "https://www.nrc.gov/",
       "codeUrl": "https://www.nrc.gov/code.json",
       "requirements": {
-        "agencyWidePolicy": 0.5,
+        "agencyWidePolicy": 1,
         "openSourceRequirement": 0,
-        "inventoryRequirement": 1,
+        "inventoryRequirement": 0,
         "schemaFormat": 0.5,
         "overallCompliance": 0
       }
@@ -292,7 +292,7 @@
       "website": "https://opm.gov/",
       "codeUrl": "https://www.opm.gov/code.json",
       "requirements": {
-        "agencyWidePolicy": 0.5,
+        "agencyWidePolicy": 0.75,
         "openSourceRequirement": 0,
         "inventoryRequirement": 0,
         "schemaFormat": 0.5,

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const request = require('request-promise')
 const errors = require('request-promise/errors')
 const fs = require('fs')
 const lunr = require('lunr')
-const { validateJson, upgradeProject, mergeJson, calculateOverallCompliance, getAgencyStatus } = require('./libs/utils')
+const { validateJson, upgradeProject, getAgencyStatus, handleError } = require('./libs/utils')
 const Reporter  = require('./libs/reporter')
 const JsonFile = require('jsonfile')
 
@@ -52,7 +52,7 @@ function format(data) {
   } else if (data.version === '2.0.0' || data.hasOwnProperty('releases')) {
     return data
   } else {
-    throw `JSON found at URL: ${requestOptions.uri} for Agency: ${data.agency} is of the wrong version or does not have the properties to determine it.`
+    throw `JSON Agency: ${data.agency} is of the wrong version or does not have the properties to determine it.`
   }
 }
 function writeReleasesFiles(releasesJson) {
@@ -87,7 +87,6 @@ function getCodeJson(requestOptions, agencyMetadata, reporter) {
     .then(function (json) {
       logger.info(`Validating JSON for Agency: ${agencyMetadata.acronym}`)
       let formattedData
-      let validationErrorMsg
 
       try {
         formattedData = JSON.parse(json.replace(/^\uFEFF/, ''))
@@ -99,10 +98,6 @@ function getCodeJson(requestOptions, agencyMetadata, reporter) {
       reporter.reportMetadata(formattedData.agency, agencyMetadata)
 
       const isCodeJsonValid = validate(formattedData, agencyMetadata, reporter)
-      const agencyStatus = getAgencyStatus(agencyMetadata)
-
-      reporter.reportStatus(agencyMetadata.acronym, agencyStatus)
-      reporter.reportRequirements(agencyMetadata.acronym, agencyMetadata.requirements)
 
       if (!isCodeJsonValid) {
         throw `Agency: ${agencyMetadata.acronym} has not passed schema validation.`
@@ -112,17 +107,22 @@ function getCodeJson(requestOptions, agencyMetadata, reporter) {
 
     })
     .catch(errors.StatusCodeError, function (reason) {
-      logger.error(`error loading: ${requestOptions.uri} - reason: statusCode ${reason.statusCode}`)
+      handleError(`error loading: ${requestOptions.uri} - reason: statusCode ${reason.statusCode}`, agencyMetadata, logger, reporter)
       return { releases: [] }
     })
     .catch(errors.RequestError, function (reason) {
-      logger.error(`error loading: ${requestOptions.uri} - reason: ${reason.cause}`)
+      handleError(`error loading: ${requestOptions.uri} - reason: ${reason.cause}`, agencyMetadata, logger, reporter)
       return { releases: [] }
     })
     .catch(function (error) {
-      logger.error(`Agency: ${agencyMetadata.acronym}`, error)
-
+      handleError(`Agency: ${agencyMetadata.acronym} - Error: ${error}`, agencyMetadata, logger, reporter)
       return { releases: [] }
+    })
+    .finally(() => {
+      const agencyStatus = getAgencyStatus(agencyMetadata)
+
+      reporter.reportStatus(agencyMetadata.acronym, agencyStatus)
+      reporter.reportRequirements(agencyMetadata.acronym, agencyMetadata.requirements)
     })
 }
 

--- a/libs/reporter.js
+++ b/libs/reporter.js
@@ -39,7 +39,7 @@ class Reporter {
 
   reportIssues(itemName, issuesObj) {
     this._createReportItemIfDoesntExist(itemName)
-    this.report.statuses[itemName]['issues'].push(issuesObj.errors)
+    issuesObj.errors.forEach(error => this.report.statuses[itemName]['issues'].push(error))
   }
 
   reportVersion(itemName, version) {


### PR DESCRIPTION
# Why

Some minor fixes were needed to polish the harvester output.

## What Changed

### Minor refactor and code cleanup. - 3103525

- Refactored error handling. Created a helper function to handle reporter and logger usage.
- Cleaned up require statements.
- Removed unused variables.

### Change values to better reflect the weight of the field. - 0b2d494

- agencyWidePolicy is now set to 0.75 if it is partially compliant to show the weight of it.
- updated agencies values.

### Change how issues are reported. - ceaad49

- Issues are now added to the reporter as individual objects.

### Minor refactor and add helper function - e8440cb

- Removed unneeded semicolons
- Added handleError helper function
- Refactored how overall compliance is calculated
- Removed getCounts
