### PR TITLE
Added USGS to agency metadata

### DIFF
--- a/data/agencyMetadata.json
+++ b/data/agencyMetadata.json
@@ -374,5 +374,19 @@
         "overallCompliance": null
       },
       "complianceDashboard": false
+    }, {
+      "id": 27,
+      "name": "U.S. Geological Survey",
+      "acronym": "USGS",
+      "website": "https://usgs.gov/",
+      "codeUrl": "https://usgs.gov/code.json",
+      "requirements": {
+        "agencyWidePolicy": null,
+        "openSourceRequirement": null,
+        "inventoryRequirement": null,
+        "schemaFormat": null,
+        "overallCompliance": null
+      },
+      "complianceDashboard": false
     }
   ]


### PR DESCRIPTION
- Added USGS to our agency metadata for collection.
- They will not be counted for the compliance dashboard.

Closes #20 