### PR TITLE
Change agency names and fix report.json creation

### DIFF
--- a/data/agencyMetadata.json
+++ b/data/agencyMetadata.json
@@ -194,7 +194,7 @@
     },
     {
       "id": 14,
-      "name": "Department of Treasury",
+      "name": "Department of the Treasury",
       "acronym": "TREASURY",
       "website": "https://www.treasury.gov/",
       "codeUrl": "https://www.treasury.gov/code.json",
@@ -334,7 +334,7 @@
       "complianceDashboard": true
     }, {
       "id": 24,
-      "name": "National Archives",
+      "name": "National Archives and Records Administration",
       "acronym": "NARA",
       "website": "https://archives.gov/",
       "codeUrl": "https://www.archives.gov/code.json",

--- a/libs/utils.js
+++ b/libs/utils.js
@@ -182,11 +182,13 @@ function calculateOverallCompliance(requirements) {
 
 function handleError(errorMsg, agencyMetadata, logger, reporter) {
   logger.error(errorMsg)
-  if(!reporter.report.statuses[agencyMetadata.acronym]) {
-    reporter.reportVersion(agencyMetadata.acronym, 'N/A')
+  if (agencyMetadata.complianceDashboard){
+    if(!reporter.report.statuses[agencyMetadata.acronym]) {
+      reporter.reportVersion(agencyMetadata.acronym, 'N/A')
+    }
+    reporter.reportMetadata(agencyMetadata.acronym, agencyMetadata)
+    reporter.reportIssues(agencyMetadata.acronym, {errors:[ {error: errorMsg} ]})
   }
-  reporter.reportMetadata(agencyMetadata.acronym, agencyMetadata)
-  reporter.reportIssues(agencyMetadata.acronym, {errors:[ {error: errorMsg} ]})
 }
 
 module.exports = {


### PR DESCRIPTION
# What Changed

- Changed NARA display name
- Changed Treasurey display name
- Added complianceDashboard validation to error handler. This will prevent agencies that are not supposed to be in the report.json to not appear

# Issues

Closes #22 