### PR TITLE
DOT acronym change on code.json from USDOT and new releases

### DIFF
--- a/data/agencyMetadata.json
+++ b/data/agencyMetadata.json
@@ -227,7 +227,7 @@
       "website": "https://epa.gov/",
       "codeUrl": "https://www.epa.gov/code.json",
       "requirements": {
-        "agencyWidePolicy": 0.75,
+        "agencyWidePolicy": 1,
         "openSourceRequirement": 0.5,
         "inventoryRequirement": 0,
         "schemaFormat": 0.5,

--- a/data/agencyMetadata.json
+++ b/data/agencyMetadata.json
@@ -180,7 +180,7 @@
     {
       "id": 13,
       "name": "Department of Transportation",
-      "acronym": "USDOT",
+      "acronym": "DOT",
       "website": "https://www.transportation.gov/",
       "codeUrl": "https://www.transportation.gov/code.json",
       "requirements": {


### PR DESCRIPTION
DOT updated their code.json file to schema 2.0.0 and better data. Also, changed their acronym from USDOT to DOT. 

Pushing EPA policy status to 1 again.